### PR TITLE
https for github pages

### DIFF
--- a/Build/Build.nuspec
+++ b/Build/Build.nuspec
@@ -4,10 +4,10 @@
     <version>0.0.0</version>
     <authors>Cameron Taggart</authors>
     <description>source linking .NET pdb files with MSBuild</description>
-    <projectUrl>http://ctaggart.github.io/SourceLink/</projectUrl>
+    <projectUrl>https://ctaggart.github.io/SourceLink/</projectUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>http://ctaggart.github.io/SourceLink/SourceLink128.jpg</iconUrl>
+    <iconUrl>https://ctaggart.github.io/SourceLink/SourceLink128.jpg</iconUrl>
     <tags>sourcelink pdb symbols git sourceindexing debugging sourceserver msbuild build</tags>
   </metadata>
   <files>

--- a/Exe/Exe.nuspec
+++ b/Exe/Exe.nuspec
@@ -4,10 +4,10 @@
     <version>0.0.0</version>
     <authors>Cameron Taggart</authors>
     <description>SourceLink: Source Code On Demand</description>
-    <projectUrl>http://ctaggart.github.io/SourceLink/</projectUrl>
+    <projectUrl>https://ctaggart.github.io/SourceLink/</projectUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>http://ctaggart.github.io/SourceLink/SourceLink128.jpg</iconUrl>
+    <iconUrl>https://ctaggart.github.io/SourceLink/SourceLink128.jpg</iconUrl>
     <tags>sourcelink pdb symbols git sourceindexing debugging sourceserver build</tags>
   </metadata>
   <files>

--- a/Exe/Index.fs
+++ b/Exe/Index.fs
@@ -86,7 +86,7 @@ let run (proj:string option) (projProps:(string * string) list)
                     let error = sprintf "%d files do not have matching checksums in Git" gc.Unmatched.Count
                     traceError error
                     traceErrorfn "make sure the source code is committed and line endings match"
-                    traceErrorfn "http://ctaggart.github.io/SourceLink/how-it-works.html"
+                    traceErrorfn "https://ctaggart.github.io/SourceLink/how-it-works.html"
                     for um in gc.Unmatched do
                         traceErrorfn "  git %s, file %s %s" um.ChecksumInGit um.ChecksumOfFile um.File
                     failwith error
@@ -103,7 +103,7 @@ let run (proj:string option) (projProps:(string * string) list)
                 let error = sprintf "%d files do not have matching checksums in Git" gc.Unmatched.Count
                 traceWarn error
                 traceWarnfn "make sure the source code is committed and line endings match"
-                traceWarnfn "http://ctaggart.github.io/SourceLink/how-it-works.html"
+                traceWarnfn "https://ctaggart.github.io/SourceLink/how-it-works.html"
                 for um in gc.Unmatched do
                     traceWarnfn "  git %s, file %s %s" um.ChecksumInGit um.ChecksumOfFile um.File
         

--- a/Fake/Fake.nuspec
+++ b/Fake/Fake.nuspec
@@ -4,10 +4,10 @@
     <version>0.0.0</version>
     <authors>Cameron Taggart</authors>
     <description>source linking .NET pdb files with FAKE - F# Make</description>
-    <projectUrl>http://ctaggart.github.io/SourceLink/</projectUrl>
+    <projectUrl>https://ctaggart.github.io/SourceLink/</projectUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>http://ctaggart.github.io/SourceLink/SourceLink128.jpg</iconUrl>
+    <iconUrl>https://ctaggart.github.io/SourceLink/SourceLink128.jpg</iconUrl>
     <tags>sourcelink pdb symbols git sourceindexing debugging sourceserver fake build</tags>
   </metadata>
   <files>

--- a/Git/Git.nuspec
+++ b/Git/Git.nuspec
@@ -6,10 +6,10 @@
     <authors>Cameron Taggart</authors>
     <!--<summary></summary>-->
     <description>Git functionality wrapping LibGit2Sharp</description>
-    <projectUrl>http://ctaggart.github.io/SourceLink/</projectUrl>
+    <projectUrl>https://ctaggart.github.io/SourceLink/</projectUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>http://ctaggart.github.io/SourceLink/SourceLink128.jpg</iconUrl>
+    <iconUrl>https://ctaggart.github.io/SourceLink/SourceLink128.jpg</iconUrl>
     @dependencies@
     <tags>sourcelink git</tags>
   </metadata>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # SourceLink [![NuGet Status](http://img.shields.io/nuget/v/SourceLink.Fake.svg?style=flat)](https://www.nuget.org/packages/SourceLink.Fake/)
-<img src="http://ctaggart.github.io/SourceLink/SourceLink128.jpg" align="right">
+<img src="https://ctaggart.github.io/SourceLink/SourceLink128.jpg" align="right">
 SourceLink is a .NET library that automates [source indexing](http://msdn.microsoft.com/en-us/library/windows/hardware/ff556898.aspx). It enables the source control management system to be the [source server](http://msdn.microsoft.com/en-us/library/windows/desktop/ms680641.aspx) by indexing the pdb files with https links to the SCM. Access to the source code is controlled by the SCM.
 
 It is documented here:
-[http://ctaggart.github.io/SourceLink/](http://ctaggart.github.io/SourceLink/)
+[https://ctaggart.github.io/SourceLink/](https://ctaggart.github.io/SourceLink/)

--- a/SourceLink/SourceLink.nuspec
+++ b/SourceLink/SourceLink.nuspec
@@ -5,10 +5,10 @@
     <authors>Cameron Taggart</authors>
     <!--<summary></summary>-->
     <description>SourceLink: Source Code On Demand</description>
-    <projectUrl>http://ctaggart.github.io/SourceLink/</projectUrl>
+    <projectUrl>https://ctaggart.github.io/SourceLink/</projectUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>http://ctaggart.github.io/SourceLink/SourceLink128.jpg</iconUrl>
+    <iconUrl>https://ctaggart.github.io/SourceLink/SourceLink128.jpg</iconUrl>
     @dependencies@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="Microsoft.Build" />

--- a/SymbolStore/SymbolStore.nuspec
+++ b/SymbolStore/SymbolStore.nuspec
@@ -6,10 +6,10 @@
     <authors>Cameron Taggart</authors>
     <!--<summary></summary>-->
     <description>interop for the .NET Symbol Store COM interfaces</description>
-    <projectUrl>http://ctaggart.github.io/SourceLink/</projectUrl>
+    <projectUrl>https://ctaggart.github.io/SourceLink/</projectUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>http://ctaggart.github.io/SourceLink/SourceLink128.jpg</iconUrl>
+    <iconUrl>https://ctaggart.github.io/SourceLink/SourceLink128.jpg</iconUrl>
     @dependencies@
     <tags>sourcelink pdb symbols sourceindexing debugging sourceserver</tags>
   </metadata>

--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -14,7 +14,7 @@
 
     <link type="text/css" rel="stylesheet" href="@Root/content/style.css" />
     <script type="text/javascript" src="@Root/content/tips.js"></script>
-    <link rel="icon" href="http://ctaggart.github.io/SourceLink/SourceLink128.jpg">
+    <link rel="icon" href="https://ctaggart.github.io/SourceLink/SourceLink128.jpg">
   </head>
   <body>
     <div class="container">
@@ -30,7 +30,7 @@
           @RenderBody()
         </div>
         <div class="span3">
-          <img src="http://ctaggart.github.io/SourceLink/SourceLink128.jpg" alt="F# Project" style="width:150px;margin:10px" />
+          <img src="https://ctaggart.github.io/SourceLink/SourceLink128.jpg" alt="F# Project" style="width:150px;margin:10px" />
           <ul class="nav nav-list" id="menu" style="margin-top: 20px;">
             <li class="nav-header">@Properties["project-name"]</li>
             <li><a href="http://www.nuget.org/packages/SourceLink.Fake"><img src="http://img.shields.io/nuget/v/SourceLink.Fake.svg?style=flat" /></a></li>


### PR DESCRIPTION
Looks like GitHub Pages got https support over the summer.
https://github.com/blog/2186-https-for-github-pages

Sadly, http://ctaggart.github.io/SourceLink/ was 404ing, but http://ctaggart.github.io/SourceLink/index.html successfully redirected.

This updates all the links to be https. I also enabled this in the hopes that the above redirect would work.

https://github.com/ctaggart/SourceLink/settings
![image](https://cloud.githubusercontent.com/assets/80104/20532110/b071ce16-b08d-11e6-9888-20d79cf9a48f.png)
