### PR TITLE
auto fix line endings

### DIFF
--- a/SourceLink.Create.GitHub/CreateTask.cs
+++ b/SourceLink.Create.GitHub/CreateTask.cs
@@ -72,8 +72,11 @@ namespace SourceLink.Create.GitHub
                     Log.LogMessage(MessageImportance.Normal, line);
             }
 
+            if (Log.HasLoggedErrors)
+                return false;
+
             SourceLink = File;
-            return !Log.HasLoggedErrors;
+            return true;
         }
 
         public static string GetRepoUrl(string origin)

--- a/dotnet-sourcelink-git/SourceFile.cs
+++ b/dotnet-sourcelink-git/SourceFile.cs
@@ -1,0 +1,12 @@
+﻿using System.Text;
+
+namespace SourceLink.Git
+{
+    public class SourceFile
+    {
+        public string FilePath { get; set; }
+        public string GitPath { get; set; }
+        public string GitHash { get; set; }
+        public string FileHash { get; set; }
+    }
+}

--- a/dotnet-sourcelink-git/dotnet-sourcelink-git.csproj
+++ b/dotnet-sourcelink-git/dotnet-sourcelink-git.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\dotnet-sourcelink\SourceLinkJson.cs" Link="SourceLinkJson.cs" />
+    <Compile Include="..\dotnet-sourcelink\System.cs" Link="System.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp.Portable" Version="0.24.10" />

--- a/dotnet-sourcelink/Program.cs
+++ b/dotnet-sourcelink/Program.cs
@@ -100,7 +100,7 @@ namespace SourceLink {
 
                 foreach (var doc in GetDocuments(path))
                 {
-                    Console.WriteLine("{0} {1} {2} {3}", toHex(doc.Hash), HashAlgorithmGuids.GetName(doc.HashAlgorithm), LanguageGuids.GetName(doc.Language), doc.Name);
+                    Console.WriteLine("{0} {1} {2} {3}", doc.Hash.ToHex(), HashAlgorithmGuids.GetName(doc.HashAlgorithm), LanguageGuids.GetName(doc.Language), doc.Name);
                 }
 
                 return 0;
@@ -132,7 +132,7 @@ namespace SourceLink {
                 {
                     if (doc.Url != null)
                     {
-                        Console.WriteLine("{0} {1} {2} {3}", toHex(doc.Hash), HashAlgorithmGuids.GetName(doc.HashAlgorithm), LanguageGuids.GetName(doc.Language), doc.Name);
+                        Console.WriteLine("{0} {1} {2} {3}", doc.Hash.ToHex(), HashAlgorithmGuids.GetName(doc.HashAlgorithm), LanguageGuids.GetName(doc.Language), doc.Name);
                         Console.WriteLine(doc.Url);
                     }
                     else
@@ -145,7 +145,7 @@ namespace SourceLink {
                     Console.WriteLine("" + missingDocs.Count + " Documents without URLs:");
                     foreach (var doc in missingDocs)
                     {
-                        Console.WriteLine("{0} {1} {2} {3}", toHex(doc.Hash), HashAlgorithmGuids.GetName(doc.HashAlgorithm), LanguageGuids.GetName(doc.Language), doc.Name);
+                        Console.WriteLine("{0} {1} {2} {3}", doc.Hash.ToHex(), HashAlgorithmGuids.GetName(doc.HashAlgorithm), LanguageGuids.GetName(doc.Language), doc.Name);
                     }
                     return 4;
                 }
@@ -182,7 +182,7 @@ namespace SourceLink {
                     {
                         if(doc.Error == null)
                         {
-                            Console.WriteLine("{0} {1} {2} {3}", toHex(doc.Hash), HashAlgorithmGuids.GetName(doc.HashAlgorithm), LanguageGuids.GetName(doc.Language), doc.Name);
+                            Console.WriteLine("{0} {1} {2} {3}", doc.Hash.ToHex(), HashAlgorithmGuids.GetName(doc.HashAlgorithm), LanguageGuids.GetName(doc.Language), doc.Name);
                             Console.WriteLine(doc.Url);
                         }
                         else
@@ -200,7 +200,7 @@ namespace SourceLink {
                     Console.WriteLine("" + missingDocs.Count + " Documents without URLs:");
                     foreach (var doc in missingDocs)
                     {
-                        Console.WriteLine("{0} {1} {2} {3}", toHex(doc.Hash), HashAlgorithmGuids.GetName(doc.HashAlgorithm), LanguageGuids.GetName(doc.Language), doc.Name);
+                        Console.WriteLine("{0} {1} {2} {3}", doc.Hash.ToHex(), HashAlgorithmGuids.GetName(doc.HashAlgorithm), LanguageGuids.GetName(doc.Language), doc.Name);
                     }
                 }
                 if (erroredDocs.Count > 0)
@@ -208,7 +208,7 @@ namespace SourceLink {
                     Console.WriteLine("" + erroredDocs.Count + " Documents with errors:");
                     foreach (var doc in erroredDocs)
                     {
-                        Console.WriteLine("{0} {1} {2} {3}", toHex(doc.Hash), HashAlgorithmGuids.GetName(doc.HashAlgorithm), LanguageGuids.GetName(doc.Language), doc.Name);
+                        Console.WriteLine("{0} {1} {2} {3}", doc.Hash.ToHex(), HashAlgorithmGuids.GetName(doc.HashAlgorithm), LanguageGuids.GetName(doc.Language), doc.Name);
                         Console.WriteLine(doc.Url);
                         Console.WriteLine("error: " + doc.Error);
                     }
@@ -258,11 +258,6 @@ namespace SourceLink {
                     };
                 }
             }
-        }
-
-        public static string toHex(byte[] bytes)
-        {
-            return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
         }
 
         public static IEnumerable<Document> GetDocumentsWithUrls(string pdb)
@@ -323,7 +318,7 @@ namespace SourceLink {
                         if (doc.Error != null) continue;
                         if (!doc.Hash.CollectionEquals(doc.UrlHash))
                         {
-                            doc.Error = "url hash does not match: " + toHex(doc.Hash);
+                            doc.Error = "url hash does not match: " + doc.Hash.ToHex();
                         }
                     }
                     yield return doc;

--- a/dotnet-sourcelink/System.cs
+++ b/dotnet-sourcelink/System.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace SourceLink
 {
     // https://github.com/ctaggart/SourceLink/blob/v1/SourceLink/SystemExtensions.fs
-    public static class SystemExtensions
+    public static class System
     {
         public static bool CollectionEquals<T>(this ICollection<T> a, ICollection<T> b)
         {
@@ -12,5 +13,11 @@ namespace SourceLink
                 return false;
             return a.SequenceEqual(b);
         }
+
+        public static string ToHex(this byte[] bytes)
+        {
+            return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
+        }
     }
+
 }


### PR DESCRIPTION
If the file hash does not match the git hash, it checks to see if removing carriage returns fixes it. If so, it updates the file. In v2, source linking happens before a compile. This avoids a ton of pain with source indexing as seen with v1 bugs:

fix #87 
fix #116 
fix #119 

Will need to update the docs here:
https://github.com/ctaggart/SourceLink/wiki/Line-Endings
