### PR TITLE
Generate intermediate output in per-config folder

### DIFF
--- a/SourceLink.Create.GitHub/SourceLink.Create.GitHub.Core.targets
+++ b/SourceLink.Create.GitHub/SourceLink.Create.GitHub.Core.targets
@@ -10,7 +10,7 @@
     <CompileDependsOn Condition="'$(SourceLinkCreate)' == 'true' and ($(DebugType) == 'portable' or $(DebugType) == 'embedded')">SourceLinkCreate;$(CompileDependsOn)</CompileDependsOn>
     <SourceLinkRepo Condition="'$(SourceLinkRepo)' == ''">$(MSBuildProjectDirectory)</SourceLinkRepo>
     <SourceLinkFile Condition="'$(SourceLinkFile)' == ''">$(SourceLink)</SourceLinkFile>
-    <SourceLinkFile Condition="'$(SourceLinkFile)' == ''">$(BaseIntermediateOutputPath)sourcelink.json</SourceLinkFile>
+    <SourceLinkFile Condition="'$(SourceLinkFile)' == ''">$(IntermediateOutputPath)sourcelink.json</SourceLinkFile>
     <SourceLinkNotInGit Condition="'$(SourceLinkNotInGit)' == ''">embed</SourceLinkNotInGit>
     <SourceLinkHashMismatch Condition="'$(SourceLinkHashMismatch)' == ''">embed</SourceLinkHashMismatch>
   </PropertyGroup>


### PR DESCRIPTION
sourcelink.json is generated for each compilation of a project (debug and release, and each target framework). It should therefore be generated into a per-configuration intermediate directory so that parallel builds do not collide or corrupt each other's result.