### PR TITLE
restore git index casing check

### DIFF
--- a/dotnet-sourcelink-git/Program.cs
+++ b/dotnet-sourcelink-git/Program.cs
@@ -173,6 +173,12 @@ namespace SourceLink.Git {
                                 {
                                     filesNotInGit.Add(sf);
                                 }
+                                else if (index.Path != sf.GitPath)
+                                {
+                                    // mysysgit sets core.ignorecase true by default
+                                    // but most web sites like GitHub are case sensitive
+                                    filesNotInGit.Add(sf);
+                                }
                                 else
                                 {
                                     sf.GitHash = index.Id.Sha;


### PR DESCRIPTION
Version 2.0.3 was created and then unlisted from NuGet Gallery, after I realized it did not fix the issue for Rx.NET #167. This check should indeed be there. This restores 2.0.2 functionality.