### PR TITLE
use SourceLink.Create.CommandLine for SourceLink

### DIFF
--- a/SourceLink.Create.BitBucket/SourceLink.Create.BitBucket.csproj
+++ b/SourceLink.Create.BitBucket/SourceLink.Create.BitBucket.csproj
@@ -37,5 +37,5 @@
     </Content>
   </ItemGroup>
 
-  <!--<Import Project="../build/sourcelink.props" />-->
+  <Import Project="../build/sourcelink.props" />
 </Project>

--- a/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.csproj
+++ b/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.csproj
@@ -37,5 +37,5 @@
     </Content>
   </ItemGroup>
 
-  <!--<Import Project="../build/sourcelink.props" />-->
+  <Import Project="../build/sourcelink.props" />
 </Project>

--- a/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.csproj
+++ b/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.csproj
@@ -37,5 +37,5 @@
     </Content>
   </ItemGroup>
 
-  <Import Project="../build/sourcelink.props" />
+  <!--<Import Project="../build/sourcelink.props" />-->
 </Project>

--- a/SourceLink.Create.GitHub/SourceLink.Create.GitHub.csproj
+++ b/SourceLink.Create.GitHub/SourceLink.Create.GitHub.csproj
@@ -33,5 +33,5 @@
     </Content>
   </ItemGroup>
 
-  <!--<Import Project="../build/sourcelink.props" />-->
+  <Import Project="../build/sourcelink.props" />
 </Project>

--- a/SourceLink.Test/SourceLink.Test.csproj
+++ b/SourceLink.Test/SourceLink.Test.csproj
@@ -37,5 +37,5 @@
     <Compile Include="..\SourceLink.Create.GitHub\Process.cs" Link="Process.cs" />
   </ItemGroup>
 
-  <!--<Import Project="../build/sourcelink.props" />-->
+  <Import Project="../build/sourcelink.props" />
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -16,6 +16,7 @@ if ($env:appveyor){
 }
 
 $pack = "pack", "-c", "release", "-o", "../bin", "/p:Version=$version$versionSuffix", "/v:m"
+$pack += "/p:ci=true"
 
 Set-Location $psscriptroot\dotnet-sourcelink
 dotnet restore
@@ -40,6 +41,14 @@ dotnet $pack
 Set-Location $psscriptroot\SourceLink.Test
 dotnet restore
 dotnet $pack
+
+Set-Location $psscriptroot\build
+dotnet restore
+$nupkgs = ls ..\bin\*$version$versionSuffix.nupkg
+foreach($nupkg in $nupkgs){
+    echo "test $nupkg"
+    dotnet sourcelink test $nupkg
+}
 
 Set-Location $psscriptroot
 

--- a/build/build.proj
+++ b/build/build.proj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="[2.1.0]" />
+  </ItemGroup>
+</Project>

--- a/build/sourcelink.props
+++ b/build/sourcelink.props
@@ -1,11 +1,5 @@
 <Project>
-  <!--<PropertyGroup>
-    <SourceLinkCreate>true</SourceLinkCreate>
-    <SourceLinkTest>true</SourceLinkTest>
-  </PropertyGroup>-->
   <ItemGroup>
     <PackageReference Include="SourceLink.Create.CommandLine" Version="[2.1.0]" PrivateAssets="all" />
-    <!--<PackageReference Include="SourceLink.Test" Version="[2.1.0]" PrivateAssets="all" />
-    <DotNetCliToolReference Include="dotnet-sourcelink" Version="[2.1.0]" />-->
   </ItemGroup>
 </Project>

--- a/build/sourcelink.props
+++ b/build/sourcelink.props
@@ -1,12 +1,11 @@
 <Project>
-  <PropertyGroup>
+  <!--<PropertyGroup>
     <SourceLinkCreate>true</SourceLinkCreate>
     <SourceLinkTest>true</SourceLinkTest>
-  </PropertyGroup>
+  </PropertyGroup>-->
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.GitHub" Version="[2.0.1]" PrivateAssets="all" />
-    <PackageReference Include="SourceLink.Test" Version="[2.0.1]" PrivateAssets="all" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="[2.0.1]" />
-    <DotNetCliToolReference Include="dotnet-sourcelink" Version="[2.0.1]" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="[2.1.0]" PrivateAssets="all" />
+    <!--<PackageReference Include="SourceLink.Test" Version="[2.1.0]" PrivateAssets="all" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="[2.1.0]" />-->
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Use SourceLink for SourceLink. This enables using SourceLink.Create.CommandLine for every project but SourceLink.Create.CommandLine. The dotnet tools appears to have problems when referencing a tool named the same as a project.