### PR TITLE
Remove check for DebugType

### DIFF
--- a/SourceLink.Create.BitBucket/SourceLink.Create.BitBucket.targets
+++ b/SourceLink.Create.BitBucket/SourceLink.Create.BitBucket.targets
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <SourceLinkCreate Condition="'$(SourceLinkCreate)' == ''">$(CI)</SourceLinkCreate>
     <SourceLinkCreate Condition="'$(SourceLinkCreate)' == '' and '$(BUILD_NUMBER)' != ''">true</SourceLinkCreate>
-    <CompileDependsOn Condition="'$(SourceLinkCreate)' == 'true' and ($(DebugType) == 'portable' or $(DebugType) == 'embedded')">SourceLinkCreate;$(CompileDependsOn)</CompileDependsOn>
+    <CompileDependsOn Condition="'$(SourceLinkCreate)' == 'true'">SourceLinkCreate;$(CompileDependsOn)</CompileDependsOn>
     <SourceLinkRepo Condition="'$(SourceLinkRepo)' == ''">$(MSBuildProjectDirectory)</SourceLinkRepo>
     <SourceLinkFile Condition="'$(SourceLinkFile)' == ''">$(SourceLink)</SourceLinkFile>
     <SourceLinkFile Condition="'$(SourceLinkFile)' == ''">$(IntermediateOutputPath)sourcelink.json</SourceLinkFile>

--- a/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.targets
+++ b/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.targets
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <SourceLinkCreate Condition="'$(SourceLinkCreate)' == ''">$(CI)</SourceLinkCreate>
     <SourceLinkCreate Condition="'$(SourceLinkCreate)' == '' and '$(BUILD_NUMBER)' != ''">true</SourceLinkCreate>
-    <CompileDependsOn Condition="'$(SourceLinkCreate)' == 'true' and ($(DebugType) == 'portable' or $(DebugType) == 'embedded')">SourceLinkCreate;$(CompileDependsOn)</CompileDependsOn>
+    <CompileDependsOn Condition="'$(SourceLinkCreate)' == 'true'">SourceLinkCreate;$(CompileDependsOn)</CompileDependsOn>
     <SourceLinkFile Condition="'$(SourceLinkFile)' == ''">$(SourceLink)</SourceLinkFile>
     <SourceLinkFile Condition="'$(SourceLinkFile)' == ''">$(IntermediateOutputPath)sourcelink.json</SourceLinkFile>
     <SourceLinkRootDirectoryCommand Condition="'$(SourceLinkRootDirectoryCommand)' == ''">git rev-parse --show-toplevel</SourceLinkRootDirectoryCommand>

--- a/SourceLink.Create.GitHub/SourceLink.Create.GitHub.targets
+++ b/SourceLink.Create.GitHub/SourceLink.Create.GitHub.targets
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <SourceLinkCreate Condition="'$(SourceLinkCreate)' == ''">$(CI)</SourceLinkCreate>
     <SourceLinkCreate Condition="'$(SourceLinkCreate)' == '' and '$(BUILD_NUMBER)' != ''">true</SourceLinkCreate>
-    <CompileDependsOn Condition="'$(SourceLinkCreate)' == 'true' and ($(DebugType) == 'portable' or $(DebugType) == 'embedded')">SourceLinkCreate;$(CompileDependsOn)</CompileDependsOn>
+    <CompileDependsOn Condition="'$(SourceLinkCreate)' == 'true'">SourceLinkCreate;$(CompileDependsOn)</CompileDependsOn>
     <SourceLinkRepo Condition="'$(SourceLinkRepo)' == ''">$(MSBuildProjectDirectory)</SourceLinkRepo>
     <SourceLinkFile Condition="'$(SourceLinkFile)' == ''">$(SourceLink)</SourceLinkFile>
     <SourceLinkFile Condition="'$(SourceLinkFile)' == ''">$(IntermediateOutputPath)sourcelink.json</SourceLinkFile>

--- a/SourceLink.Embed.PaketFiles/SourceLink.Embed.PaketFiles.targets
+++ b/SourceLink.Embed.PaketFiles/SourceLink.Embed.PaketFiles.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildDependsOn>EmbedPaketFiles;$(BuildDependsOn)</BuildDependsOn>
+    <BuildDependsOn Condition="$(DebugType) == 'portable' or $(DebugType) == 'embedded'">EmbedPaketFiles;$(BuildDependsOn)</BuildDependsOn>
   </PropertyGroup>
   <Target Name="EmbedPaketFiles">
     <ItemGroup>

--- a/SourceLink.Embed.PaketFiles/SourceLink.Embed.PaketFiles.targets
+++ b/SourceLink.Embed.PaketFiles/SourceLink.Embed.PaketFiles.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildDependsOn Condition="$(DebugType) == 'portable' or $(DebugType) == 'embedded'">EmbedPaketFiles;$(BuildDependsOn)</BuildDependsOn>
+    <BuildDependsOn>EmbedPaketFiles;$(BuildDependsOn)</BuildDependsOn>
   </PropertyGroup>
   <Target Name="EmbedPaketFiles">
     <ItemGroup>

--- a/SourceLink.Test/SourceLink.Test.targets
+++ b/SourceLink.Test/SourceLink.Test.targets
@@ -8,9 +8,9 @@
   <PropertyGroup>
     <SourceLinkTest Condition="'$(SourceLinkTest)' == ''">$(CI)</SourceLinkTest>
     <SourceLinkTest Condition="'$(SourceLinkTest)' == '' and '$(BUILD_NUMBER)' != ''">true</SourceLinkTest>
-    <CompileDependsOn Condition="'$(SourceLinkTest)' == 'true' and ($(DebugType) == 'portable' or $(DebugType) == 'embedded')">$(CompileDependsOn);SourceLinkTest</CompileDependsOn>
+    <CompileDependsOn Condition="'$(SourceLinkTest)' == 'true'">$(CompileDependsOn);SourceLinkTest</CompileDependsOn>
     <SourceLinkPdb Condition="'$(SourceLinkPdb)' == ''">$(PdbFile)</SourceLinkPdb>
-    <SourceLinkPdb Condition="'$(SourceLinkPdb)' == '' and $(DebugType) == 'portable'">$(IntermediateOutputPath)$(TargetName).pdb</SourceLinkPdb>
+    <SourceLinkPdb Condition="'$(SourceLinkPdb)' == '' and ($(DebugType) != 'embedded' and $(DebugType) != 'none')">$(IntermediateOutputPath)$(TargetName).pdb</SourceLinkPdb>
     <SourceLinkPdb Condition="'$(SourceLinkPdb)' == '' and $(DebugType) == 'embedded'">$(IntermediateOutputPath)$(TargetName).dll</SourceLinkPdb>
   </PropertyGroup>
 


### PR DESCRIPTION
Roslyn compilers support Sourcelink in VS 2017 15.3

I would like this added so we can support SourceLink in the [NodeTools](github.com/microsoft/nodejstools/) repo.

This fixes #194 