### PR TITLE
Added `SourceLinkServerType` to `SourceLink.Create.CommandLine`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The [source link documention](https://github.com/dotnet/core/blob/master/Documen
 
 If you are building on Windows, make sure that you configure git to checkout files with [core.autocrlf input](https://github.com/ctaggart/SourceLink/wiki/Line-Endings).
 
+By default `SourceLink.Create.CommandLine` will try to process GitHub and BitBucket cloned repositories. You can specify a specific server type by setting the `SourceLinkServerType` MSBuild property like `/p:SourceLinkServerType=GitHub`, `/p:SourceLinkServerType=BitBucket` or `/p:SourceLinkServerType=BitBucketServer`.
+
 You can control when it runs by setting the `SourceLinkCreate` property. That property is set to `true` by default on build servers that set `CI` or `BUILD_NUMBER` environment variables. In general these tools are meant to be run only on build servers, but you can test locally by setting an MSBuild property like `/p:ci=true` or `/p:SourceLinkCreate=true`.
 
 If you have a dotnet project, you can test locally with:

--- a/SourceLink.Create.CommandLine/CreateTask.cs
+++ b/SourceLink.Create.CommandLine/CreateTask.cs
@@ -69,15 +69,17 @@ namespace SourceLink.Create.CommandLine
         {
             var urlConverters = new List<UrlConverter>();
 
-            switch (serverType)
+            var normalizeServerType = serverType?.ToUpperInvariant();
+
+            switch (normalizeServerType)
             {
-                case "GitHub":
+                case "GITHUB":
                     urlConverters.Add(GitHub.UrlConverter.Convert);
                     break;
-                case "BitBucket":
+                case "BITBUCKET":
                     urlConverters.Add(BitBucket.UrlConverter.Convert);
                     break;
-                case "BitBucketServer":
+                case "BITBUCKETSERVER":
                     urlConverters.Add(BitBucketServer.UrlConverter.Convert);
                     break;
                 default:

--- a/SourceLink.Create.CommandLine/CreateTask.cs
+++ b/SourceLink.Create.CommandLine/CreateTask.cs
@@ -20,6 +20,8 @@ namespace SourceLink.Create.CommandLine
         [Required]
         public string File { get; set; }
 
+        public string ServerType { get;set; }
+
         [Output]
         public string SourceLink { get; set; }
 
@@ -33,7 +35,7 @@ namespace SourceLink.Create.CommandLine
                     Log.LogError("OriginUrl not set");
                     return false;
                 }
-                url = ConvertUrl(OriginUrl);
+                url = ConvertUrl(OriginUrl, ServerType);
                 Log.LogMessage(MessageImportance.Normal, "SourceLinkUrl: " + url);
                 if (url == null)
                 {
@@ -63,18 +65,34 @@ namespace SourceLink.Create.CommandLine
 
         public delegate string UrlConverter(string url);
 
-        public static string ConvertUrl(string origin)
+        public static string ConvertUrl(string origin, string serverType)
         {
-            var urlConverters = new List<UrlConverter> {
-                GitHub.UrlConverter.Convert,
-                BitBucket.UrlConverter.Convert
-            };
+            var urlConverters = new List<UrlConverter>();
+
+            switch (serverType)
+            {
+                case "GitHub":
+                    urlConverters.Add(GitHub.UrlConverter.Convert);
+                    break;
+                case "BitBucket":
+                    urlConverters.Add(BitBucket.UrlConverter.Convert);
+                    break;
+                case "BitBucketServer":
+                    urlConverters.Add(BitBucketServer.UrlConverter.Convert);
+                    break;
+                default:
+                    urlConverters.Add(GitHub.UrlConverter.Convert);
+                    urlConverters.Add(BitBucket.UrlConverter.Convert);
+                    break;
+            }
+
             foreach(var urlConverter in urlConverters)
             {
                 var url = urlConverter(origin);
                 if (url != null)
                     return url;
             }
+
             return null;
         }
 

--- a/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.csproj
+++ b/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\SourceLink.Create.BitBucket\BitBucketUrlConverter.cs" Link="BitBucketUrlConverter.cs" />
+    <Compile Include="..\SourceLink.Create.BitBucketServer\BitBucketServerUrlConverter.cs" Link="BitBucketServerUrlConverter.cs" /> 
     <Compile Include="..\SourceLink.Create.GitHub\GitHubUrlConverter.cs" Link="GitHubUrlConverter.cs" />
   </ItemGroup>
 

--- a/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.targets
+++ b/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.targets
@@ -32,7 +32,8 @@
         Url="$(SourceLinkUrl)"
         OriginUrl="$(SourceLinkOriginUrl)"
         Commit="$(SourceLinkCommit)"
-        File="$(SourceLinkFile)">
+        File="$(SourceLinkFile)"
+        ServerType="$(SourceLinkServerType)">
       <Output PropertyName="SourceLink" TaskParameter="SourceLink" />
     </SourceLink.Create.CommandLine.CreateTask>
   </Target>


### PR DESCRIPTION
Fixes #264 

Added `SourceLinkServerType` to `SourceLink.Create.CommandLine` to allow user to specify the specific server type to use ("GitHub", "BitBucket", "BitBucketServer") to use when generating the url. If `SourceLinkServerType` is not specified, then defaults to trying the GitHub url parser first, then BitBucket (Cloud).