### PR TITLE
support basic authentication

### DIFF
--- a/dotnet-sourcelink/AuthenticationHeaderProvider.cs
+++ b/dotnet-sourcelink/AuthenticationHeaderProvider.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace SourceLink
+{
+    public interface IAuthenticationHeaderValueProvider
+    {
+        AuthenticationHeaderValue GetValue();
+    }
+
+    internal class BasicAuthenticationHeaderValueProvider : IAuthenticationHeaderValueProvider
+    {
+        private readonly string _username;
+        private readonly string _password;
+        private readonly Encoding _encoding;
+
+        public BasicAuthenticationHeaderValueProvider(string username, string password, Encoding encoding = null)
+        {
+            if (string.IsNullOrWhiteSpace(username)) throw new ArgumentNullException(nameof(username),"Invalid username value");
+            if (string.IsNullOrWhiteSpace(password)) throw new ArgumentNullException(nameof(password),"Invalid password value");
+
+            _username = username;
+            _password = password;
+            _encoding = encoding ?? Encoding.ASCII;
+        }
+
+        public AuthenticationHeaderValue GetValue()
+        {
+            return new AuthenticationHeaderValue("Basic", Convert.ToBase64String(_encoding.GetBytes($"{_username}:{_password}")));
+        }
+    }
+}

--- a/dotnet-sourcelink/dotnet-sourcelink.csproj
+++ b/dotnet-sourcelink/dotnet-sourcelink.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NuGet.Packaging" Version="4.0.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
   <Import Project="..\dotnet-sourcelink-shared\dotnet-sourcelink-shared.projitems" Label="Shared" />
   <Import Project="../build/sourcelink.props" />


### PR DESCRIPTION
Basic support for `Basic` authentication for test command. Fix for #256

* Added command line options for authentication type (only basic to start with) and username and password

* Added Interface for getting the Authentication Header to make extending to other authentication types in the future easier

* Added Authentication Header Provider for Basic authentication

**Questions**:
1. I think supporting other means besides entering username and password in the commandline is important for automation scenarios. Would you be happy if we added an option to read authentication details from a file or environment variables or pass in the encoded value?