### PR TITLE
Fix slash in ReadMe suggestion to avoid pack bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Please vote for all of these issues:
   </PropertyGroup>
   <Target Name="IncludePDBsInPackage" Condition="'$(IncludeBuildOutput)' != 'false'">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).pdb" PackagePath="lib/$(TargetFramework)" />
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).pdb" PackagePath="lib\$(TargetFramework)" />
     </ItemGroup>
   </Target>
   ```


### PR DESCRIPTION
If you follow the approach suggested in the Known Issue and ask MSBuild to produce a package with symbols (i.e. `MSBuild /t:Pack /p:IncludeSources=true`), you will get a corrupted package. The produced symbol package will contain the `pdb` file twice and will not be a valid archive. I spent more than one day to troubleshoot this stuff and finally found that MSBuild task has a mechanism to prevent duplicates, however it relies on the target path. The suggested path contains invalid slash, so `pdb` file is added twice.

After applying the fix I suggested the produced symbol package will be valid, but you will get warnings during the pack:
`
C:\Program Files\dotnet\sdk\2.0.0\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(141,5): warning : File 'C:\Projects\AutoFixture_LF\Src
\AutoFixture\bin\Release\net452\Ploeh.AutoFixture.pdb' is not added because the package already contains file 'lib\net452\Ploeh.AutoFixture.pdb' [C:\Projects\AutoFixtu
re_LF\Src\AutoFixture\AutoFixture.csproj]
C:\Program Files\dotnet\sdk\2.0.0\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(141,5): warning : File 'C:\Projects\AutoFixture_LF\Src
\AutoFixture\bin\Release\netstandard1.5\Ploeh.AutoFixture.pdb' is not added because the package already contains file 'lib\netstandard1.5\Ploeh.AutoFixture.pdb' [C:\Pr
ojects\AutoFixture_LF\Src\AutoFixture\AutoFixture.csproj]
`
In any case, it's much better than the corrupted package without any warnings.

P.S. You might wounder why I need the symbol package if I use SourceLink. The answer is simple - to support people using older versions of VS.