### PR TITLE
OpenWrite overwrites and does not share

### DIFF
--- a/SourceLink.Create.CommandLine/CreateTask.cs
+++ b/SourceLink.Create.CommandLine/CreateTask.cs
@@ -50,7 +50,7 @@ namespace SourceLink.Create.CommandLine
             rootDirectory += '*';
             rootDirectory = rootDirectory.Replace(@"\", @"\\"); // json escape
 
-            using (var json = new IO.StreamWriter(IO.File.OpenWrite(File)))
+            using (var json = FileUtil.OpenWrite(File))
             {
                 json.Write("{\"documents\":{\"");
                 json.Write(rootDirectory);

--- a/SourceLink.Create.Shared/FileUtil.cs
+++ b/SourceLink.Create.Shared/FileUtil.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace SourceLink.Create
+{
+    public static class FileUtil
+    {
+        public static StreamWriter OpenWrite(string file) {
+            return new StreamWriter(File.Open(file, FileMode.Create, FileAccess.Write, FileShare.None));
+        }
+    }
+}

--- a/SourceLink.Create.Shared/GitCreateTask.cs
+++ b/SourceLink.Create.Shared/GitCreateTask.cs
@@ -56,7 +56,7 @@ namespace SourceLink.Create
             }
 
             var compileFile = IO.Path.ChangeExtension(File, ".compile");
-            using (var sw = new IO.StreamWriter(IO.File.OpenWrite(compileFile)))
+            using (var sw = FileUtil.OpenWrite(compileFile))
             {
                 if (Sources != null)
                 {

--- a/SourceLink.Create.Shared/SourceLink.Create.Shared.projitems
+++ b/SourceLink.Create.Shared/SourceLink.Create.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>SourceLink.Create</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)FileUtil.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitCreateTask.cs" />
   </ItemGroup>
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-$version = '2.6.1' # the version under development, update after a release
+$version = '2.7.0' # the version under development, update after a release
 $versionSuffix = '-a125' # manually incremented for local builds
 
 function isVersionTag($tag){

--- a/dotnet-sourcelink-git/Program.cs
+++ b/dotnet-sourcelink-git/Program.cs
@@ -252,7 +252,7 @@ namespace SourceLink.Git {
                     }
                 };
 
-                using (var sw = new StreamWriter(File.OpenWrite(file)))
+                using (var sw = FileUtil.OpenWrite(file))
                 {
                     var js = new JsonSerializer();
                     js.Serialize(sw, json);
@@ -262,7 +262,7 @@ namespace SourceLink.Git {
                 if (embedFiles.Count > 0)
                 {
                     Console.WriteLine("embedding " + embedFiles.Count + " source files");
-                    using (var sw = new StreamWriter(File.OpenWrite(embedFile)))
+                    using (var sw = FileUtil.OpenWrite(embedFile))
                     {
                         foreach (var sf in embedFiles)
                         {

--- a/dotnet-sourcelink-shared/FileUtil.cs
+++ b/dotnet-sourcelink-shared/FileUtil.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace SourceLink
+{
+    public static class FileUtil
+    {
+        public static StreamWriter OpenWrite(string file) {
+            return new StreamWriter(File.Open(file, FileMode.Create, FileAccess.Write, FileShare.None));
+        }
+    }
+}

--- a/dotnet-sourcelink-shared/dotnet-sourcelink-shared.projitems
+++ b/dotnet-sourcelink-shared/dotnet-sourcelink-shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>SourceLink</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)FileUtil.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SourceLinkJson.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Version.cs" />


### PR DESCRIPTION
This is to address #289.

Tested it with a locally build FsAutoComplete where paket.dependencies had:
```
group SourceLink
  storage: none
  source https://ci.appveyor.com/nuget/sourcelink/
  nuget SourceLink.Create.CommandLine 2.7.0-b622
  nuget SourceLink.Embed.PaketFiles 2.7.0-b622
```