### PR TITLE
F# + dotnet-sourcelink-git not embedding source

### DIFF
--- a/SourceLink.Create.BitBucket/SourceLink.Create.BitBucket.targets
+++ b/SourceLink.Create.BitBucket/SourceLink.Create.BitBucket.targets
@@ -34,6 +34,9 @@
       <Output PropertyName="SourceLink" TaskParameter="SourceLink" />
       <Output ItemName="EmbeddedFiles" TaskParameter="EmbeddedFiles" />
     </SourceLink.Create.BitBucket.CreateTask>
+    <CreateProperty Value="@(EmbeddedFiles)">  
+      <Output TaskParameter="Value" PropertyName="embed" />  
+    </CreateProperty>
   </Target>
 
 </Project>

--- a/SourceLink.Create.BitBucket/SourceLink.Create.BitBucket.targets
+++ b/SourceLink.Create.BitBucket/SourceLink.Create.BitBucket.targets
@@ -32,9 +32,15 @@
         HashMismatch="$(SourceLinkHashMismatch)"
         EmbeddedFilesIn="@(EmbeddedFiles)">
       <Output PropertyName="SourceLink" TaskParameter="SourceLink" />
-      <Output ItemName="EmbeddedFiles" TaskParameter="EmbeddedFiles" />
-    </SourceLink.Create.BitBucket.CreateTask>
-    <CreateProperty Value="@(EmbeddedFiles)">  
+      <Output ItemName="_EmbeddedFiles" TaskParameter="EmbeddedFiles" />
+    </SourceLink.Create.GitHub.CreateTask>
+    <ItemGroup>
+      <EmbeddedFiles Include="@(_EmbeddedFiles)" />
+      <FullPathEmbeddedFiles
+          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
+    </ItemGroup>
+    <CreateProperty Value="@(FullPathEmbeddedFiles)">  
       <Output TaskParameter="Value" PropertyName="embed" />  
     </CreateProperty>
   </Target>

--- a/SourceLink.Create.BitBucketServer/SourceLink.Create.BitBucketServer.targets
+++ b/SourceLink.Create.BitBucketServer/SourceLink.Create.BitBucketServer.targets
@@ -32,9 +32,15 @@
         HashMismatch="$(SourceLinkHashMismatch)"
         EmbeddedFilesIn="@(EmbeddedFiles)">
       <Output PropertyName="SourceLink" TaskParameter="SourceLink" />
-      <Output ItemName="EmbeddedFiles" TaskParameter="EmbeddedFiles" />
-    </SourceLink.Create.BitBucketServer.CreateTask>
-    <CreateProperty Value="@(EmbeddedFiles)">  
+      <Output ItemName="_EmbeddedFiles" TaskParameter="EmbeddedFiles" />
+    </SourceLink.Create.GitHub.CreateTask>
+    <ItemGroup>
+      <EmbeddedFiles Include="@(_EmbeddedFiles)" />
+      <FullPathEmbeddedFiles
+          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
+    </ItemGroup>
+    <CreateProperty Value="@(FullPathEmbeddedFiles)">  
       <Output TaskParameter="Value" PropertyName="embed" />  
     </CreateProperty>
   </Target>

--- a/SourceLink.Create.BitBucketServer/SourceLink.Create.BitBucketServer.targets
+++ b/SourceLink.Create.BitBucketServer/SourceLink.Create.BitBucketServer.targets
@@ -34,6 +34,9 @@
       <Output PropertyName="SourceLink" TaskParameter="SourceLink" />
       <Output ItemName="EmbeddedFiles" TaskParameter="EmbeddedFiles" />
     </SourceLink.Create.BitBucketServer.CreateTask>
+    <CreateProperty Value="@(EmbeddedFiles)">  
+      <Output TaskParameter="Value" PropertyName="embed" />  
+    </CreateProperty>
   </Target>
 
 </Project>

--- a/SourceLink.Create.GitHub/SourceLink.Create.GitHub.targets
+++ b/SourceLink.Create.GitHub/SourceLink.Create.GitHub.targets
@@ -32,9 +32,15 @@
         HashMismatch="$(SourceLinkHashMismatch)"
         EmbeddedFilesIn="@(EmbeddedFiles)">
       <Output PropertyName="SourceLink" TaskParameter="SourceLink" />
-      <Output ItemName="EmbeddedFiles" TaskParameter="EmbeddedFiles" />
+      <Output ItemName="_EmbeddedFiles" TaskParameter="EmbeddedFiles" />
     </SourceLink.Create.GitHub.CreateTask>
-    <CreateProperty Value="@(EmbeddedFiles)">  
+    <ItemGroup>
+      <EmbeddedFiles Include="@(_EmbeddedFiles)" />
+      <FullPathEmbeddedFiles
+          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
+    </ItemGroup>
+    <CreateProperty Value="@(FullPathEmbeddedFiles)">  
       <Output TaskParameter="Value" PropertyName="embed" />  
     </CreateProperty>
   </Target>

--- a/SourceLink.Create.GitHub/SourceLink.Create.GitHub.targets
+++ b/SourceLink.Create.GitHub/SourceLink.Create.GitHub.targets
@@ -34,6 +34,9 @@
       <Output PropertyName="SourceLink" TaskParameter="SourceLink" />
       <Output ItemName="EmbeddedFiles" TaskParameter="EmbeddedFiles" />
     </SourceLink.Create.GitHub.CreateTask>
+    <CreateProperty Value="@(EmbeddedFiles)">  
+      <Output TaskParameter="Value" PropertyName="embed" />  
+    </CreateProperty>
   </Target>
 
 </Project>

--- a/SourceLink.Create.GitLab/SourceLink.Create.GitLab.targets
+++ b/SourceLink.Create.GitLab/SourceLink.Create.GitLab.targets
@@ -34,5 +34,8 @@
       <Output PropertyName="SourceLink" TaskParameter="SourceLink" />
       <Output ItemName="EmbeddedFiles" TaskParameter="EmbeddedFiles" />
     </SourceLink.Create.GitLab.CreateTask>
+    <CreateProperty Value="@(EmbeddedFiles)">  
+      <Output TaskParameter="Value" PropertyName="embed" />  
+    </CreateProperty>
   </Target>
 </Project>

--- a/SourceLink.Create.GitLab/SourceLink.Create.GitLab.targets
+++ b/SourceLink.Create.GitLab/SourceLink.Create.GitLab.targets
@@ -32,10 +32,17 @@
         HashMismatch="$(SourceLinkHashMismatch)"
         EmbeddedFilesIn="@(EmbeddedFiles)">
       <Output PropertyName="SourceLink" TaskParameter="SourceLink" />
-      <Output ItemName="EmbeddedFiles" TaskParameter="EmbeddedFiles" />
-    </SourceLink.Create.GitLab.CreateTask>
-    <CreateProperty Value="@(EmbeddedFiles)">  
+      <Output ItemName="_EmbeddedFiles" TaskParameter="EmbeddedFiles" />
+    </SourceLink.Create.GitHub.CreateTask>
+    <ItemGroup>
+      <EmbeddedFiles Include="@(_EmbeddedFiles)" />
+      <FullPathEmbeddedFiles
+          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
+    </ItemGroup>
+    <CreateProperty Value="@(FullPathEmbeddedFiles)">  
       <Output TaskParameter="Value" PropertyName="embed" />  
     </CreateProperty>
   </Target>
+
 </Project>


### PR DESCRIPTION
F# projects currently use `embed` property instead of EmbeddedFiles itemgroup. I reported this in https://github.com/Microsoft/visualfsharp/issues/2767 and it has popped up again in https://github.com/Microsoft/visualfsharp/issues/4075.