### PR TITLE
help embed files for F# projects with SourceLink.Create.CommandLine

### DIFF
--- a/SourceLink.Create.BitBucket/SourceLink.Create.BitBucket.targets
+++ b/SourceLink.Create.BitBucket/SourceLink.Create.BitBucket.targets
@@ -37,7 +37,7 @@
     <ItemGroup>
       <EmbeddedFiles Include="@(_EmbeddedFiles)" />
       <FullPathEmbeddedFiles
-          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Condition="$([System.IO.File]::Exists('%(EmbeddedFiles.Identity)'))"
           Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
     </ItemGroup>
     <CreateProperty Value="@(FullPathEmbeddedFiles)">  

--- a/SourceLink.Create.BitBucketServer/SourceLink.Create.BitBucketServer.targets
+++ b/SourceLink.Create.BitBucketServer/SourceLink.Create.BitBucketServer.targets
@@ -37,7 +37,7 @@
     <ItemGroup>
       <EmbeddedFiles Include="@(_EmbeddedFiles)" />
       <FullPathEmbeddedFiles
-          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Condition="$([System.IO.File]::Exists('%(EmbeddedFiles.Identity)'))"
           Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
     </ItemGroup>
     <CreateProperty Value="@(FullPathEmbeddedFiles)">  

--- a/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.targets
+++ b/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.targets
@@ -38,7 +38,7 @@
     </SourceLink.Create.CommandLine.CreateTask>
     <ItemGroup>
       <FullPathEmbeddedFiles
-          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Condition="$([System.IO.File]::Exists('%(EmbeddedFiles.Identity)'))"
           Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
     </ItemGroup>
     <CreateProperty Value="@(FullPathEmbeddedFiles)">  

--- a/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.targets
+++ b/SourceLink.Create.CommandLine/SourceLink.Create.CommandLine.targets
@@ -36,6 +36,14 @@
         ServerType="$(SourceLinkServerType)">
       <Output PropertyName="SourceLink" TaskParameter="SourceLink" />
     </SourceLink.Create.CommandLine.CreateTask>
+    <ItemGroup>
+      <FullPathEmbeddedFiles
+          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
+    </ItemGroup>
+    <CreateProperty Value="@(FullPathEmbeddedFiles)">  
+      <Output TaskParameter="Value" PropertyName="embed" />  
+    </CreateProperty>
   </Target>
 
 </Project>

--- a/SourceLink.Create.GitHub/SourceLink.Create.GitHub.targets
+++ b/SourceLink.Create.GitHub/SourceLink.Create.GitHub.targets
@@ -37,7 +37,7 @@
     <ItemGroup>
       <EmbeddedFiles Include="@(_EmbeddedFiles)" />
       <FullPathEmbeddedFiles
-          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Condition="$([System.IO.File]::Exists('%(EmbeddedFiles.Identity)'))"
           Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
     </ItemGroup>
     <CreateProperty Value="@(FullPathEmbeddedFiles)">  

--- a/SourceLink.Create.GitLab/SourceLink.Create.GitLab.targets
+++ b/SourceLink.Create.GitLab/SourceLink.Create.GitLab.targets
@@ -37,7 +37,7 @@
     <ItemGroup>
       <EmbeddedFiles Include="@(_EmbeddedFiles)" />
       <FullPathEmbeddedFiles
-          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Condition="$([System.IO.File]::Exists('%(EmbeddedFiles.Identity)'))"
           Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
     </ItemGroup>
     <CreateProperty Value="@(FullPathEmbeddedFiles)">  

--- a/SourceLink.Embed.AllSourceFiles/SourceLink.Embed.AllSourceFiles.targets
+++ b/SourceLink.Embed.AllSourceFiles/SourceLink.Embed.AllSourceFiles.targets
@@ -7,7 +7,7 @@
       <AllSourceFiles Include="%(Compile.Identity)" />
       <EmbeddedFiles Include="@(AllSourceFiles)" />
       <FullPathEmbeddedFiles
-          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Condition="$([System.IO.File]::Exists('%(EmbeddedFiles.Identity)'))"
           Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
     </ItemGroup>
     <CreateProperty Value="@(EmbeddedFiles)">  

--- a/SourceLink.Embed.AllSourceFiles/SourceLink.Embed.AllSourceFiles.targets
+++ b/SourceLink.Embed.AllSourceFiles/SourceLink.Embed.AllSourceFiles.targets
@@ -4,7 +4,11 @@
   </PropertyGroup>
   <Target Name="EmbedAllSourceFiles">
     <ItemGroup>
-      <EmbeddedFiles Include="$([System.IO.Path]::GetFullPath('%(Compile.Identity)'))" />
+      <AllSourceFiles Include="%(Compile.Identity)" />
+      <EmbeddedFiles Include="@(AllSourceFiles)" />
+      <FullPathEmbeddedFiles
+          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
     </ItemGroup>
     <CreateProperty Value="@(EmbeddedFiles)">  
       <Output TaskParameter="Value" PropertyName="embed" />  

--- a/SourceLink.Embed.PaketFiles/SourceLink.Embed.PaketFiles.targets
+++ b/SourceLink.Embed.PaketFiles/SourceLink.Embed.PaketFiles.targets
@@ -5,11 +5,11 @@
   <Target Name="EmbedPaketFiles">
     <ItemGroup>
       <PaketFiles
-          Condition="$([System.String]::Copy('%(Identity)').Contains('paket-files'))"
+          Condition="$([System.String]::Copy('%(Compile.Identity)').Contains('paket-files'))"
           Include="%(Compile.Identity)" />
       <EmbeddedFiles Include="@(PaketFiles)" />
       <FullPathEmbeddedFiles
-          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Condition="$([System.IO.File]::Exists('%(EmbeddedFiles.Identity)'))"
           Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
     </ItemGroup>
     <CreateProperty Value="@(FullPathEmbeddedFiles)">  

--- a/SourceLink.Embed.PaketFiles/SourceLink.Embed.PaketFiles.targets
+++ b/SourceLink.Embed.PaketFiles/SourceLink.Embed.PaketFiles.targets
@@ -4,10 +4,15 @@
   </PropertyGroup>
   <Target Name="EmbedPaketFiles">
     <ItemGroup>
-      <EmbeddedFiles Include="$([System.IO.Path]::GetFullPath('%(Compile.Identity)'))"
-        Condition="$([System.String]::Copy('%(Identity)').Contains('paket-files'))" />
+      <PaketFiles
+          Condition="$([System.String]::Copy('%(Identity)').Contains('paket-files'))"
+          Include="%(Compile.Identity)" />
+      <EmbeddedFiles Include="@(PaketFiles)" />
+      <FullPathEmbeddedFiles
+          Condition="$([System.IO.File]::Exists('%(Identity)'))"
+          Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
     </ItemGroup>
-    <CreateProperty Value="@(EmbeddedFiles)">  
+    <CreateProperty Value="@(FullPathEmbeddedFiles)">  
       <Output TaskParameter="Value" PropertyName="embed" />  
     </CreateProperty>
   </Target>

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-$version = '2.7.0' # the version under development, update after a release
+$version = '2.7.2' # the version under development, update after a release
 $versionSuffix = '-a125' # manually incremented for local builds
 
 function isVersionTag($tag){


### PR DESCRIPTION


currently not passing with:
```
C:\Users\appveyor\.nuget\packages\sourcelink.create.commandline\2.7.2-b652\build\SourceLink.Create.CommandLine.targets(42,11): error MSB4184: The expression "[System.IO.Path]::GetFullPath('')" cannot be evaluated. The path is not of a legal form. [C:\projects\fsautocomplete\src\FsAutoComplete.Core.VerboseSdkHelper.netcore\FsAutoComplete.Core.VerboseSdkHelper.fsproj]
```