### PR TITLE
SourceLink.Create.BitBucketServer.targets error

### DIFF
--- a/SourceLink.Create.BitBucketServer/SourceLink.Create.BitBucketServer.targets
+++ b/SourceLink.Create.BitBucketServer/SourceLink.Create.BitBucketServer.targets
@@ -33,7 +33,7 @@
         EmbeddedFilesIn="@(EmbeddedFiles)">
       <Output PropertyName="SourceLink" TaskParameter="SourceLink" />
       <Output ItemName="_EmbeddedFiles" TaskParameter="EmbeddedFiles" />
-    </SourceLink.Create.GitHub.CreateTask>
+    </SourceLink.Create.BitBucketServer.CreateTask>
     <ItemGroup>
       <EmbeddedFiles Include="@(_EmbeddedFiles)" />
       <FullPathEmbeddedFiles


### PR DESCRIPTION
SourceLink.Create.BitBucketServer.targets contains wrong closing tag for SourceLink.Create.BitBucketServer.CreateTask.