### PR TITLE
SourceLink.Copy.PdbFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The [source link support documention](https://github.com/dotnet/core/blob/master
 ``` xml
 <Project>
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.6" PrivateAssets="All" /> 
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" /> 
   </ItemGroup>
 </Project>
 ```
@@ -49,7 +49,7 @@ As of SourceLink 2.7, the pdb files will automatically be included in your nupkg
 
 Install by adding:
 ``` xml
-<DotNetCliToolReference Include="dotnet-sourcelink" Version="2.7.6" />
+<DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
 ```
 
 # Embedding Source Files
@@ -60,13 +60,25 @@ For source files are not committed to the repository, it is helpful to embed the
 
 If you just want to embed all of the source files in the pdb and not use source link support, add this package:
 ``` xml
-<PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.7.6" PrivateAssets="all" />
+<PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.0" PrivateAssets="all" />
 ```
 
 # Documentation
 Additional [documentation is on the wiki](https://github.com/ctaggart/SourceLink/wiki).
 
 # Known Issues
+
+- New project system does not copy PDBs from packages when targeting .NET Framework
+
+  Add `SourceLink.Copy.PdbFiles` to your project file. See [#313](https://github.com/ctaggart/SourceLink/issues/313) for details.
+
+``` xml
+<Project>
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Copy.PdbFiles" Version="2.8.0" PrivateAssets="All" /> 
+  </ItemGroup>
+</Project>
+```
 
 - Private repositories are not supported
 

--- a/SourceLink.Copy.PdbFiles/SourceLink.Copy.PdbFiles.csproj
+++ b/SourceLink.Copy.PdbFiles/SourceLink.Copy.PdbFiles.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../build/common.props" />
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+  <ItemGroup Label="dotnet pack instructions">
+    <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
+    <Content Include="SourceLink.Copy.PdbFiles.props">
+      <Pack>true</Pack>
+      <PackagePath>build</PackagePath>
+    </Content>
+    <Content Include="SourceLink.Copy.PdbFiles.props">
+      <Pack>true</Pack>
+      <PackagePath>buildCrossTargeting</PackagePath>
+    </Content>
+    <Content Include="SourceLink.Copy.PdbFiles.targets">
+      <Pack>true</Pack>
+      <PackagePath>build</PackagePath>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/SourceLink.Copy.PdbFiles/SourceLink.Copy.PdbFiles.props
+++ b/SourceLink.Copy.PdbFiles/SourceLink.Copy.PdbFiles.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <AllowedReferenceRelatedFileExtensions>$(AllowedReferenceRelatedFileExtensions);.pdb</AllowedReferenceRelatedFileExtensions>
+  </PropertyGroup>
+</Project>

--- a/SourceLink.Copy.PdbFiles/SourceLink.Copy.PdbFiles.targets
+++ b/SourceLink.Copy.PdbFiles/SourceLink.Copy.PdbFiles.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Target Name="AddReferenceRelatedPathsToCopyLocal" AfterTargets="ResolveAssemblyReferences"
-      Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp' and $(TargetFrameworkIdentifier)' != '.NETStandard'">
+      Condition="('$(TargetFrameworkIdentifier)' != '.NETCoreApp') and ('$(TargetFrameworkIdentifier)' != '.NETStandard')">
     <ItemGroup>
       <ReferenceCopyLocalPaths Include="@(_ReferenceRelatedPaths)" />
     </ItemGroup>

--- a/SourceLink.Copy.PdbFiles/SourceLink.Copy.PdbFiles.targets
+++ b/SourceLink.Copy.PdbFiles/SourceLink.Copy.PdbFiles.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Target Name="AddReferenceRelatedPathsToCopyLocal" AfterTargets="ResolveAssemblyReferences"
-      Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+      Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp' and $(TargetFrameworkIdentifier)' != '.NETStandard'">
     <ItemGroup>
       <ReferenceCopyLocalPaths Include="@(_ReferenceRelatedPaths)" />
     </ItemGroup>

--- a/SourceLink.Copy.PdbFiles/SourceLink.Copy.PdbFiles.targets
+++ b/SourceLink.Copy.PdbFiles/SourceLink.Copy.PdbFiles.targets
@@ -1,0 +1,7 @@
+﻿<Project>
+  <Target Name="AddReferenceRelatedPathsToCopyLocal" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Include="@(_ReferenceRelatedPaths)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/SourceLink.Copy.PdbFiles/SourceLink.Copy.PdbFiles.targets
+++ b/SourceLink.Copy.PdbFiles/SourceLink.Copy.PdbFiles.targets
@@ -1,5 +1,6 @@
 ﻿<Project>
-  <Target Name="AddReferenceRelatedPathsToCopyLocal" AfterTargets="ResolveAssemblyReferences">
+  <Target Name="AddReferenceRelatedPathsToCopyLocal" AfterTargets="ResolveAssemblyReferences"
+      Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <ItemGroup>
       <ReferenceCopyLocalPaths Include="@(_ReferenceRelatedPaths)" />
     </ItemGroup>

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-$version = '2.7.7' # the version under development, update after a release
+$version = '2.8.0' # the version under development, update after a release
 $versionSuffix = '-a125' # manually incremented for local builds
 
 function isVersionTag($tag){
@@ -55,6 +55,10 @@ dotnet restore
 dotnet $pack
 
 Set-Location $psscriptroot\SourceLink.Embed.PaketFiles
+dotnet restore
+dotnet $pack
+
+Set-Location $psscriptroot\SourceLink.Copy.PdbFiles
 dotnet restore
 dotnet $pack
 


### PR DESCRIPTION
`SourceLink.Copy.PdbFiles` just packages up the workaround @jnm2 came up with to address https://github.com/ctaggart/SourceLink/issues/313.

I'm guessing we may need to add some conditions so that this only applied to netfx.