### PR TITLE
Handle visualstudio.com origins

### DIFF
--- a/SourceLink.Create.VSTS/CreateTask.cs
+++ b/SourceLink.Create.VSTS/CreateTask.cs
@@ -1,0 +1,10 @@
+﻿namespace SourceLink.Create.VSTS
+{
+    public class CreateTask : GitCreateTask
+    {
+        public override string ConvertUrl(string origin)
+        {
+            return UrlConverter.Convert(origin);
+        }
+    }
+}

--- a/SourceLink.Create.VSTS/SourceLink.Create.VSTS.csproj
+++ b/SourceLink.Create.VSTS/SourceLink.Create.VSTS.csproj
@@ -1,0 +1,48 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../build/common.props" />
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.4;net461</TargetFrameworks>
+    <!-- https://VSTS.com/NuGet/Home/wiki/Adding-nuget-pack-as-a-msbuild-target -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409" PrivateAssets="all" />
+    <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- https://docs.microsoft.com/en-us/dotnet/articles/core/preview3/tools/extensibility -->
+  <ItemGroup Label="dotnet pack instructions">
+    <Content Include="SourceLink.Create.VSTS.props">
+      <Pack>true</Pack>
+      <PackagePath>build</PackagePath>
+    </Content>
+    <Content Include="SourceLink.Create.VSTS.props">
+      <Pack>true</Pack>
+      <PackagePath>buildCrossTargeting</PackagePath>
+    </Content>
+    <Content Include="SourceLink.Create.VSTS.targets">
+      <Pack>true</Pack>
+      <PackagePath>build</PackagePath>
+    </Content>
+
+    <Content Include="$(OutputPath)netstandard1.4/SourceLink.Create.VSTS.dll">
+      <Pack>true</Pack>
+      <PackagePath>build/netstandard1.4</PackagePath>
+    </Content>
+    <Content Include="$(OutputPath)netstandard1.4/SourceLink.Create.VSTS.deps.json">
+      <Pack>true</Pack>
+      <PackagePath>build/netstandard1.4</PackagePath>
+    </Content>
+
+    <Content Include="$(OutputPath)net461/SourceLink.Create.VSTS.dll">
+      <Pack>true</Pack>
+      <PackagePath>build/net461</PackagePath>
+    </Content>
+  </ItemGroup>
+  <Import Project="..\SourceLink.Create.Shared\SourceLink.Create.Shared.projitems" Label="Shared" />
+  <Import Project="..\SourceLink.Shared\SourceLink.Shared.projitems" Label="Shared" />
+
+  <Import Project="../build/sourcelink.props" />
+</Project>

--- a/SourceLink.Create.VSTS/SourceLink.Create.VSTS.props
+++ b/SourceLink.Create.VSTS/SourceLink.Create.VSTS.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+</Project>

--- a/SourceLink.Create.VSTS/SourceLink.Create.VSTS.targets
+++ b/SourceLink.Create.VSTS/SourceLink.Create.VSTS.targets
@@ -1,0 +1,48 @@
+﻿<Project>
+  <PropertyGroup>
+    <SourceLinkCreateVSTSDll Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard1.4\SourceLink.Create.VSTS.dll</SourceLinkCreateVSTSDll>
+    <SourceLinkCreateVSTSDll Condition="'$(MSBuildRuntimeType)' != 'Core'">net461\SourceLink.Create.VSTS.dll</SourceLinkCreateVSTSDll>
+  </PropertyGroup>
+  <UsingTask TaskName="SourceLink.Create.VSTS.CreateTask" AssemblyFile="$(SourceLinkCreateVSTSDll)" />
+
+  <PropertyGroup>
+    <SourceLinkCreate Condition="'$(SourceLinkCreate)' == ''">$(CI)</SourceLinkCreate>
+    <SourceLinkCreate Condition="'$(SourceLinkCreate)' == '' and '$(BUILD_NUMBER)' != ''">true</SourceLinkCreate>
+    <SourceLinkCreate Condition="'$(SourceLinkCreate)' == '' and '$(TF_BUILD)' != ''">true</SourceLinkCreate>
+    <CompileDependsOn Condition="'$(SourceLinkCreate)' == 'true'">SourceLinkCreate;$(CompileDependsOn)</CompileDependsOn>
+    <SourceLinkRepo Condition="'$(SourceLinkRepo)' == ''">$(MSBuildProjectDirectory)</SourceLinkRepo>
+    <SourceLinkFile Condition="'$(SourceLinkFile)' == ''">$(SourceLink)</SourceLinkFile>
+    <SourceLinkFile Condition="'$(SourceLinkFile)' == ''">$(IntermediateOutputPath)sourcelink.json</SourceLinkFile>
+    <SourceLinkNotInGit Condition="'$(SourceLinkNotInGit)' == ''">embed</SourceLinkNotInGit>
+    <SourceLinkHashMismatch Condition="'$(SourceLinkHashMismatch)' == ''">embed</SourceLinkHashMismatch>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SourceLinkSources Condition="'@(SourceLinkSources)' == ''" Include="@(Compile)" Exclude="@(EmbeddedFiles)" />
+  </ItemGroup>
+
+  <Target Name="SourceLinkCreate">
+    <SourceLink.Create.VSTS.CreateTask
+        GitDirectory="$(SourceLinkGitDirectory)"
+        Url="$(SourceLinkUrl)"
+        File="$(SourceLinkFile)"
+        Sources="@(SourceLinkSources)"
+        NoAutoLF="$(SourceLinkNoAutoLF)"
+        NotInGit="$(SourceLinkNotInGit)"
+        HashMismatch="$(SourceLinkHashMismatch)"
+        EmbeddedFilesIn="@(EmbeddedFiles)">
+      <Output PropertyName="SourceLink" TaskParameter="SourceLink" />
+      <Output ItemName="_EmbeddedFiles" TaskParameter="EmbeddedFiles" />
+    </SourceLink.Create.VSTS.CreateTask>
+    <ItemGroup>
+      <EmbeddedFiles Include="@(_EmbeddedFiles)" />
+      <FullPathEmbeddedFiles
+          Condition="$([System.IO.File]::Exists('%(EmbeddedFiles.Identity)'))"
+          Include="$([System.IO.Path]::GetFullPath('%(EmbeddedFiles.Identity)'))" />
+    </ItemGroup>
+    <CreateProperty Value="@(FullPathEmbeddedFiles)">
+      <Output TaskParameter="Value" PropertyName="embed" />
+    </CreateProperty>
+  </Target>
+
+</Project>

--- a/SourceLink.Create.VSTS/VSTSUrlConverter.cs
+++ b/SourceLink.Create.VSTS/VSTSUrlConverter.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.RegularExpressions;
+
+namespace SourceLink.Create.VSTS
+{
+    public static class UrlConverter
+    {
+        private static Regex VSTSUriMatcher = new Regex("https://(?<tenant>\\w+).visualstudio.com/(DefaultCollection/)?(?<project>\\w+)/_git/(?<repo>\\w+)", RegexOptions.IgnoreCase);
+        public static string Convert(string origin)
+        {
+            var match = VSTSUriMatcher.Match(origin);
+            if (match == null)
+                return null;
+
+            return $"https://{match.Groups["tenant"].Value}.visualstudio.com/DefaultCollection/_apis/git/{match.Groups["project"].Value}/repositories/{match.Groups["repo"].Value}/items?api-version=1.0&versionType=commit&version={{commit}}&scopePath=*";
+        }
+    }
+}

--- a/SourceLink.sln
+++ b/SourceLink.sln
@@ -55,6 +55,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{853D5303
 		build.ps1 = build.ps1
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SourceLink.Create.VSTS", "SourceLink.Create.VSTS\SourceLink.Create.VSTS.csproj", "{65D97DBD-A718-47A5-A334-3B76D371417F}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		SourceLink.Embed.Shared\SourceLink.Embed.Shared.projitems*{083cd576-0be4-4aac-86d8-00e50c660759}*SharedItemsImports = 13
@@ -203,6 +205,18 @@ Global
 		{81801FB5-9388-43BA-B8FD-508A428C03CF}.Release|x64.Build.0 = Release|Any CPU
 		{81801FB5-9388-43BA-B8FD-508A428C03CF}.Release|x86.ActiveCfg = Release|Any CPU
 		{81801FB5-9388-43BA-B8FD-508A428C03CF}.Release|x86.Build.0 = Release|Any CPU
+		{65D97DBD-A718-47A5-A334-3B76D371417F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65D97DBD-A718-47A5-A334-3B76D371417F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65D97DBD-A718-47A5-A334-3B76D371417F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{65D97DBD-A718-47A5-A334-3B76D371417F}.Debug|x64.Build.0 = Debug|Any CPU
+		{65D97DBD-A718-47A5-A334-3B76D371417F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{65D97DBD-A718-47A5-A334-3B76D371417F}.Debug|x86.Build.0 = Debug|Any CPU
+		{65D97DBD-A718-47A5-A334-3B76D371417F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65D97DBD-A718-47A5-A334-3B76D371417F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65D97DBD-A718-47A5-A334-3B76D371417F}.Release|x64.ActiveCfg = Release|Any CPU
+		{65D97DBD-A718-47A5-A334-3B76D371417F}.Release|x64.Build.0 = Release|Any CPU
+		{65D97DBD-A718-47A5-A334-3B76D371417F}.Release|x86.ActiveCfg = Release|Any CPU
+		{65D97DBD-A718-47A5-A334-3B76D371417F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -222,6 +236,7 @@ Global
 		{F157756B-2442-4131-848B-CBEF39E8F706} = {07737978-28A8-42A2-A240-A66EF5EC4C5E}
 		{CB177CE6-ADA8-4017-B5B3-579B72B67B2A} = {07737978-28A8-42A2-A240-A66EF5EC4C5E}
 		{B1B7304A-FB72-435B-920F-B2DC53DA6054} = {07737978-28A8-42A2-A240-A66EF5EC4C5E}
+		{65D97DBD-A718-47A5-A334-3B76D371417F} = {F157756B-2442-4131-848B-CBEF39E8F706}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7623516C-0410-449C-9EFC-84B884102D70}

--- a/Tests/Integration/When_package_without_lib_is_installed.cs
+++ b/Tests/Integration/When_package_without_lib_is_installed.cs
@@ -13,6 +13,7 @@ namespace Tests.Integration
         [InlineData("SourceLink.Create.CommandLine")]
         [InlineData("SourceLink.Create.GitHub")]
         [InlineData("SourceLink.Create.GitLab")]
+        [InlineData("SourceLink.Create.VSTS")]
         [InlineData("SourceLink.Embed.AllSourceFiles")]
         [InlineData("SourceLink.Embed.PaketFiles")]
         [InlineData("SourceLink.Test")]

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\SourceLink.Create.BitBucket\SourceLink.Create.BitBucket.csproj" />
     <ProjectReference Include="..\SourceLink.Create.BitBucketServer\SourceLink.Create.BitBucketServer.csproj" />
     <ProjectReference Include="..\SourceLink.Create.GitHub\SourceLink.Create.GitHub.csproj" />
+    <ProjectReference Include="..\SourceLink.Create.VSTS\SourceLink.Create.VSTS.csproj" />
     <ProjectReference Include="..\SourceLink.Create.GitLab\SourceLink.Create.GitLab.csproj" />
   </ItemGroup>
 
@@ -29,6 +30,7 @@
       <ProjectForPackageTesting Include="..\SourceLink.Create.BitBucketServer\SourceLink.Create.BitBucketServer.csproj" />
       <ProjectForPackageTesting Include="..\SourceLink.Create.CommandLine\SourceLink.Create.CommandLine.csproj" />
       <ProjectForPackageTesting Include="..\SourceLink.Create.GitHub\SourceLink.Create.GitHub.csproj" />
+      <ProjectForPackageTesting Include="..\SourceLink.Create.VSTS\SourceLink.Create.VSTS.csproj" />
       <ProjectForPackageTesting Include="..\SourceLink.Create.GitLab\SourceLink.Create.GitLab.csproj" />
       <ProjectForPackageTesting Include="..\SourceLink.Embed.AllSourceFiles\SourceLink.Embed.AllSourceFiles.csproj" />
       <ProjectForPackageTesting Include="..\SourceLink.Embed.PaketFiles\SourceLink.Embed.PaketFiles.csproj" />

--- a/Tests/When_parsing_links.cs
+++ b/Tests/When_parsing_links.cs
@@ -16,6 +16,15 @@ namespace Tests
         }
 
         [Theory]
+        [InlineData("https://fabrikam.visualstudio.com/SomeProject/_git/SomeRepo")]
+        [InlineData("https://fabrikam.visualstudio.com/DefaultCollection/SomeProject/_git/SomeRepo")]
+        public void Should_return_url_in_canonical_form_for_VSTS(string provided)
+        {
+            var task = new SourceLink.Create.VSTS.CreateTask();
+            Assert.Equal("https://fabrikam.visualstudio.com/DefaultCollection/_apis/git/SomeProject/repositories/SomeRepo/items?api-version=1.0&versionType=commit&version={commit}&scopePath=*", task.ConvertUrl(provided));
+        }
+
+        [Theory]
         [InlineData("git@gitlab.com:ctaggart/sourcelink-test.git")]
         [InlineData("https://gitlab.com/ctaggart/sourcelink-test.git")]
         [InlineData("https://gitlab.com/ctaggart/sourcelink-test")]


### PR DESCRIPTION
This PR ads support for origins hosted on visualstudio.com.

I know it might be missing editor support for the authenticated access to VSTS's API, but at list the pdb generation part should be covered by this.

I will run an experiment locally to see how this works in practice, but I leave the code here for feedback.