### PR TITLE
build tags in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,8 @@
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema
 trigger:
-  - refs/heads/*
-  - refs/tags/*
+  - +:refs/heads/*
+  - +:refs/pull/*/merge
+  - +:refs/tags/*
 pool:
   vmImage: 'VS2017-Win2016'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema
 trigger:
+  - refs/heads/*
   - refs/tags/*
 pool:
   vmImage: 'VS2017-Win2016'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
-# https://docs.microsoft.com/vsts/pipelines/languages/dotnet-core
-
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema
+trigger:
+  - refs/tags/*
 pool:
   vmImage: 'VS2017-Win2016'
 
@@ -10,7 +11,7 @@ steps:
     cd Tests
     dotnet restore
     dotnet test -l trx
-  # displayName: 'build'
+
 
 - task: PublishTestResults@2
   inputs:


### PR DESCRIPTION
> Hi Cameron. You can create a build/release pipeline with a branch filter that looks like this (or customized to match your release tag format): refs/tags/* 
https://twitter.com/dstaheli/status/1043635525918380033

The branch, tags, and pull requests are not building with:
```
trigger:
  - refs/heads/*
  - refs/tags/*
```

I know that in Teamcity, the branch spec is this:
```
+:refs/heads/*
+:refs/pull/*/merge
+:refs/tags/*
```